### PR TITLE
FIXED sprockets_build

### DIFF
--- a/lib/microservice_precompiler/builder.rb
+++ b/lib/microservice_precompiler/builder.rb
@@ -157,9 +157,8 @@ module MicroservicePrecompiler
       asset = asset.to_s
       # Minify JS
       return Uglifier.compile(asset) if format.eql?("js")
-      # CSS COMPRESSOR NOT NEEDED AS IT IS ALREADY COMPACT
       # Minify CSS
-      #return YUI::CssCompressor.new.compress(asset) if format.eql?(".css")
+      return YUI::CssCompressor.new.compress(asset) if format.eql?("css")
     end
 
     # Get the mustache config file with fullpath

--- a/lib/microservice_precompiler/builder.rb
+++ b/lib/microservice_precompiler/builder.rb
@@ -156,9 +156,10 @@ module MicroservicePrecompiler
     def minify(asset, format)
       asset = asset.to_s
       # Minify JS
-      return Uglifier.compile(asset) if format.eql?(".js")
+      return Uglifier.compile(asset) if format.eql?("js")
+      # CSS COMPRESSOR NOT NEEDED AS IT IS ALREADY COMPACT
       # Minify CSS
-      return YUI::CssCompressor.new.compress(asset) if format.eql?(".css")
+      #return YUI::CssCompressor.new.compress(asset) if format.eql?(".css")
     end
 
     # Get the mustache config file with fullpath

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,4 @@
- require 'simplecov'
+require 'simplecov'
 SimpleCov.start
 require 'coveralls'
 Coveralls.wear!

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,4 @@
-require 'simplecov'
+ require 'simplecov'
 SimpleCov.start
 require 'coveralls'
 Coveralls.wear!

--- a/test/unit/builder_test.rb
+++ b/test/unit/builder_test.rb
@@ -1,4 +1,4 @@
- require 'rubygems'
+require 'rubygems'
 require 'test_helper'
 
 class BuilderTest < Test::Unit::TestCase

--- a/test/unit/builder_test.rb
+++ b/test/unit/builder_test.rb
@@ -1,4 +1,4 @@
-require 'rubygems'
+ require 'rubygems'
 require 'test_helper'
 
 class BuilderTest < Test::Unit::TestCase


### PR DESCRIPTION
- javscript was having errors cause of the minify function. The format required for js files is 'js' and not '.js'

-Also Minify function needs to only function over js files cause css files are minified at the time of creation
- Change made https://github.com/Amay22/microservice_precompiler/blob/master/lib/microservice_precompiler/builder.rb#L159-L162

- Issue raised Issue https://github.com/barnabyalter/microservice_precompiler/issues/4