### PR TITLE
Bug/matching wrong extension on asset save

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: ruby
 rvm:
   - 2.0.0
   - 2.1.6
+  - 2.2.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: ruby
 rvm:
   - 2.0.0
   - 2.1.6
-  - 2.2.0

--- a/lib/microservice_precompiler/builder.rb
+++ b/lib/microservice_precompiler/builder.rb
@@ -84,8 +84,6 @@ module MicroservicePrecompiler
     end
     alias_method :mustache, :mustache_build
 
-  private
-
     def method_missing(method_id, *args)
       if match = matches_file_exists_check?(method_id)
         File.exists?(send(method_id.to_s.gsub(/_exists\?/,"")))
@@ -93,6 +91,8 @@ module MicroservicePrecompiler
         super
       end
     end
+
+  private
 
     # Render mustache into html for complex directory structure
     # Loop through each directory matched to a set of mustache classes/subclasses

--- a/test/unit/builder_test.rb
+++ b/test/unit/builder_test.rb
@@ -18,9 +18,7 @@ class BuilderTest < Test::Unit::TestCase
     assert_equal(precompiler.build_path, @project_root + "/dist")
     assert_not_nil(precompiler.mustaches_filename)
     assert_equal(precompiler.mustaches_filename, "mustaches.yml.tml")
-    assert_raises(ArgumentError){ precompiler.build_path = @project_root }
     assert_raises(ArgumentError){ precompiler = MicroservicePrecompiler::Builder.new(".", "./") }
-
   end
 
   def test_cleanup
@@ -58,6 +56,27 @@ class BuilderTest < Test::Unit::TestCase
     assert((File.exists? "#{@project_root}/dist"), "The build path does not exist")
     assert((File.exists? "#{@project_root}/dist/templates"), "No templates folder found")
     assert((File.exists? "#{@project_root}/dist/templates/Sample.html"), "File not found.")
+  end
+
+  def test_build_path
+    assert_nothing_raised(){ @precompiler.build_path = "./dist" }
+    assert_raises(ArgumentError){ @precompiler.build_path = @project_root }
+  end
+
+  def test_compile
+    assert_nothing_raised(){ mustache = @precompiler.compile }
+    assert((File.exists? "#{@project_root}/dist"), "The build path does not exist")
+    assert((File.exists? "#{@project_root}/dist/javascripts"), "No javascripts folder found")
+    assert((File.exists? "#{@project_root}/dist/stylesheets"), "No stylesheets folder found")
+    assert((File.exists? "#{@project_root}/dist/templates"), "No templates folder found")
+  end
+
+  def test_method_missing
+    assert_raises(NoMethodError) { @precompiler.no_method }
+  end
+
+  def test_minify
+    assert_equal(@precompiler.send(:minify, "Test value to not minimize", "html"), "Test value to not minimize", "Minify did not correctly pass through the test value")
   end
 
 

--- a/test/unit/builder_test.rb
+++ b/test/unit/builder_test.rb
@@ -18,6 +18,9 @@ class BuilderTest < Test::Unit::TestCase
     assert_equal(precompiler.build_path, @project_root + "/dist")
     assert_not_nil(precompiler.mustaches_filename)
     assert_equal(precompiler.mustaches_filename, "mustaches.yml.tml")
+    assert_raise_with_message(ArgumentError, "project_root and build_path cannot be the same"){ precompiler.build_path = @project_root }
+    assert_raise_with_message(ArgumentError, "project_root and build_path cannot be the same"){ precompiler = MicroservicePrecompiler::Builder.new(".", "./") }
+
   end
 
   def test_cleanup
@@ -45,7 +48,8 @@ class BuilderTest < Test::Unit::TestCase
     assert((File.size("#{@project_root}/stylesheets/screen.css") > File.size("#{@project_root}/dist/stylesheets/screen.css")), "Stylesheets were not minimized.")
     assert((File.exists? "#{@project_root}/dist/javascripts"), "No javascripts folder found, sprockets build failed")
     #Check that the files in javascripts are minimized
-    #TODO
+    assert((File.exists? "#{@project_root}/dist/javascripts/sample.js"), "Compiled javascript not found, sprockets build failed")
+    assert((File.size("#{@project_root}/javascripts/sample.js.coffee") < File.size("#{@project_root}/dist/javascripts/sample.js")), "Javascripts were not minimized.")
   end
 
   def test_mustache_build

--- a/test/unit/builder_test.rb
+++ b/test/unit/builder_test.rb
@@ -18,8 +18,8 @@ class BuilderTest < Test::Unit::TestCase
     assert_equal(precompiler.build_path, @project_root + "/dist")
     assert_not_nil(precompiler.mustaches_filename)
     assert_equal(precompiler.mustaches_filename, "mustaches.yml.tml")
-    assert_raise_with_message(ArgumentError, "project_root and build_path cannot be the same"){ precompiler.build_path = @project_root }
-    assert_raise_with_message(ArgumentError, "project_root and build_path cannot be the same"){ precompiler = MicroservicePrecompiler::Builder.new(".", "./") }
+    assert_raises(ArgumentError){ precompiler.build_path = @project_root }
+    assert_raises(ArgumentError){ precompiler = MicroservicePrecompiler::Builder.new(".", "./") }
 
   end
 


### PR DESCRIPTION
- Changed compile to look at correct extension syntax, i.e. "js" instead of ".js"
- Added ArgumentError if `build_path` and `project_root` are the same
